### PR TITLE
Adding missing translations for new IOF 2018 symbols

### DIFF
--- a/src/lang/fi.js
+++ b/src/lang/fi.js
@@ -48,6 +48,7 @@ const fi = {
   "Pit": "Pieni kaivettu kuoppa",
   "Broken ground": "Pienimuotoinen alue",
   "Ant hill": "Muurahaispesä",
+  "Trench": "",
   "Cliff, crag": "Jyrkänne",
   "Rock pillar": "Kivipilari",
   "Cave": "Luola",
@@ -100,6 +101,7 @@ const fi = {
   "Statue": "Monumentti, patsas",
   "Canopy": "Käytävä läpi talon",
   "Stairway": "Portaat",
+  "Out of bounds area": "Kielletty alue",
   "Special item": "Erikoiskohde"
 };
 export default {fi};

--- a/src/lang/xx.js
+++ b/src/lang/xx.js
@@ -49,6 +49,7 @@ const xx = {
   "Pit": "",
   "Broken ground": "",
   "Ant hill": "",
+  "Trench": "",
   "Cliff, crag": "",
   "Rock pillar": "",
   "Cave": "",
@@ -101,6 +102,7 @@ const xx = {
   "Statue": "",
   "Canopy": "",
   "Stairway": "",
+  "Out of bounds area": "",
   "Special item": ""
 };
 export default {xx};


### PR DESCRIPTION
This fix will only include missing translations. Please also fix changed symbols for Boulder, Boulder Cluster, Dot Knoll.